### PR TITLE
Add star size multiplication feature

### DIFF
--- a/lib/star.dart
+++ b/lib/star.dart
@@ -35,12 +35,12 @@ class Star {
     this.color,
   );
 
-  factory Star.random({bool isBigStar = false, required starColors, required List<StarShape> starShapes}) {
+  factory Star.random({bool isBigStar = false, required starColors, required List<StarShape> starShapes, double sizeMultiplier = 1}) {
     final random = Random();
 
     return Star(
       Offset(random.nextDouble(), random.nextDouble()),
-      isBigStar ? (random.nextDouble() * 4 + 3) : (random.nextDouble() * 2 + 0.5),
+      (isBigStar ? (random.nextDouble() * 4 + 3) : (random.nextDouble() * 2 + 0.5)) * sizeMultiplier,
       random.nextDouble() * 0.5 + 0.3,
       random.nextDouble() * 2 + 1,
       random.nextDouble() * 2 - 1,

--- a/lib/twinkling_stars_background.dart
+++ b/lib/twinkling_stars_background.dart
@@ -8,6 +8,7 @@ class TwinklingStarsBackground extends StatefulWidget {
   final bool includeBigStars;
   final List<Color> starColors;
   final List<StarShape> starShapes;
+  final double sizeMultiplier;
 
   const TwinklingStarsBackground({
     super.key,
@@ -16,6 +17,7 @@ class TwinklingStarsBackground extends StatefulWidget {
     this.includeBigStars = true,
     this.starColors = const [Colors.white],
     this.starShapes = const [StarShape.fivePoint],
+    this.sizeMultiplier = 1,
   });
 
   @override
@@ -40,6 +42,7 @@ class _TwinklingStarsBackgroundState extends State<TwinklingStarsBackground>
         isBigStar: isBig,
         starColors: widget.starColors,
         starShapes: widget.starShapes,
+        sizeMultiplier: widget.sizeMultiplier,
       );
     });
   }


### PR DESCRIPTION
Hi! Nice library, I really like its simple API :)

I found the stars to be a little on the small side for my use case. As such I decided to fork and add this multiplier parameter.

Minor unrelated note: The Git link in pub.dev points to `twinkling_stars` while this repo is called `twinkling_star`.